### PR TITLE
fix: post-install failing + unix crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,32 @@
 
 ## Requirements
 
-In order for chrollo to work, `mpv` is required to be installed.
+In order for Chrollo to work, mpv is required to be installed. When installing with npm, Chrollo will attempt to install mpv automatically using our post install script. This will create a local installation of mpv isolated specifically for Chrollo. In the event where your operating system is unsupported by Chrollo's auto installer, you may need to install mpv globally by following the instructions below:
 
-You can follow the steps [here](https://mpv.io/installation/).
+### Windows
+
+With [chocolatey](https://chocolatey.org/):
+
+```bash
+choco install mpv
+```
+
+### OSX
+
+With [brew](https://brew.sh/):
+
+```bash
+brew install mpv
+```
+
+### Linux
+
+```bash
+sudo apt update
+sudo apt install mpv
+```
+
+Or, you can follow the steps [here](https://mpv.io/installation/) for other mpv installation methods.
 
 ## Installation
 
@@ -31,9 +54,7 @@ With [npm](https://npmjs.org/):
 npm install -g chrollo
 ```
 
-To use chrollo on the command line, install chrollo via npm, then you should be able to run `chrollo` from the command line.
-
-Note: You need **an engine that supports ES6 (e.g. Babel or Node 4.0+)**.
+To use Chrollo on the command line, install Chrollo via npm, then you should be able to run `chrollo` from the command line.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "tsc && node ./lib/index.js",
     "clean": "rm -rf ./node_modules ./package-lock.json && npm install",
     "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write",
-    "postinstall": "node ./lib/scripts/postinstall.js"
+    "postinstall": "npm run build && node ./lib/scripts/postinstall.js"
   },
   "author": "wuon",
   "license": "MIT",
@@ -37,7 +37,6 @@
     "axios": "^0.23.0",
     "chalk": "^4.1.2",
     "command-exists": "^1.2.9",
-    "figlet": "^1.5.2",
     "got": "^11.8.2",
     "inquirer": "^8.2.0",
     "node-html-parser": "^5.0.0",

--- a/src/scripts/lib/prompts.ts
+++ b/src/scripts/lib/prompts.ts
@@ -1,19 +1,19 @@
 import chalk from 'chalk';
 
-export const ΘinstallationCompleted = chalk`
+export const installationCompleted = chalk`
 {green Installation process complete!}
 
 Chrollo is ready for you, simply enter {bold chrollo} in your terminal to discover the world of {red a}{rgb(241, 118, 28) n}{yellow i}{green m}{blue e}!
 `;
 
-export const ΘmpvNotFoundWarning = chalk.yellow(
-  'Chrollo requires mpv to work. Please make sure mpv is installed before using Chrollo.',
+export const mpvNotFoundWarning = chalk.yellow(
+  'Chrollo requires mpv to work. Please make sure mpv is installed before using Chrollo.'
 );
 
-export const ΘautoInstallNotSupported = chalk.red(
-  `Oh no... You are using an operating system Chrollo doesn't support, you must install mpv on your own.`,
+export const autoInstallNotSupported = chalk.red(
+  `Oh no... You are using an operating system where Chrollo's auto mpv installer isn't supported yet, you must install mpv on your own.`
 );
 
-export const ΘautoInstallFailed = chalk.red(
-  `Oh no... Auto mpv installation failed, you must install mpv on your own.`,
+export const autoInstallFailed = chalk.red(
+  `Oh no... The mpv auto installation failed, you must install mpv on your own.`
 );

--- a/src/scripts/lib/utils.ts
+++ b/src/scripts/lib/utils.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import crypto from 'crypto';
-import { exec } from 'child_process';
 
 export const validateFileHash = (fileName: string, hash: string) =>
   new Promise<boolean>((resolve) => {
@@ -12,14 +11,3 @@ export const validateFileHash = (fileName: string, hash: string) =>
     const hex = hashSum.digest('hex');
     setTimeout(() => resolve(checkHex === hex), 1000);
   });
-
-export const isMPVInstalled = () => {
-  return new Promise<boolean>((resolve) => {
-    exec('mpv --version', (error) => {
-      if (error) {
-        resolve(false);
-      }
-      resolve(true);
-    });
-  });
-};

--- a/src/scripts/postinstall.ts
+++ b/src/scripts/postinstall.ts
@@ -3,10 +3,10 @@ import commandExists from 'command-exists';
 import inquirer from 'inquirer';
 
 import {
-  ΘinstallationCompleted,
-  ΘmpvNotFoundWarning,
-  ΘautoInstallNotSupported,
-  ΘautoInstallFailed
+  installationCompleted,
+  mpvNotFoundWarning,
+  autoInstallNotSupported,
+  autoInstallFailed
 } from './lib/prompts';
 import {
   winDownloadArchive,
@@ -32,9 +32,9 @@ const main = async () => {
     if (shouldInstall) {
       await installMPVBinary();
     } else {
-      console.log(ΘmpvNotFoundWarning);
+      console.log(mpvNotFoundWarning);
     }
-    console.log(ΘinstallationCompleted);
+    console.log(installationCompleted);
   }
 };
 
@@ -47,7 +47,7 @@ const installMPVBinary = async () => {
     case 'darwin':
     case 'linux':
     default:
-      console.log(ΘautoInstallNotSupported);
+      console.log(autoInstallNotSupported);
   }
 };
 
@@ -61,7 +61,7 @@ const installMPVForWindows = async () => {
     }
     await winUnzipArchive(fileName);
   } catch (e) {
-    console.log(ΘautoInstallFailed);
+    console.log(autoInstallFailed);
   }
 };
 

--- a/src/sections/init.ts
+++ b/src/sections/init.ts
@@ -1,8 +1,9 @@
 import commandExists from 'command-exists';
 import fs from 'fs';
 
-const isMPVInstalled = () => {
-  const exists = commandExists.sync('mpv --version') || fs.existsSync('./bin');
+const isMPVInstalled = async () => {
+  const exists =
+    (await commandExists.sync('mpv --version')) || fs.existsSync('./bin');
   if (!exists) {
     console.log(
       "Looks like you don't have mpv installed. You will need it to run chrollo!"


### PR DESCRIPTION
### Fixed
- `commandExists.sync('mpv --version')` is asynchronous but was being called synchronously. This resulting in environments without `mpv` locally installed with chrollo to exit abruptly
- when cloning and installing chrollo, the postinstall npm command would fail since the `./lib` was not initialised yet